### PR TITLE
Replacing 1b'X with 1'bX

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This small program converts a KiCad netlist into a verilog description.
 The units of the schematics are mapped to verilog modules.
 The parameters of the modules correspond to the pin numbers of the unit.
-Vcc is mapped to `1b'1` and GND to `1b'0`.
+Vcc is mapped to `1'b1` and GND to `1'b0`.
 
 To generate a netlist, open the schematic and choose
 

--- a/kicad_to_verilog.py
+++ b/kicad_to_verilog.py
@@ -113,9 +113,9 @@ if __name__ == "__main__":
             print(f'{mangle(val)} {mangle(c)} (')
             for pin, net in pins.items():
                 if net in vcc:
-                    net = "1b'1"
+                    net = "1'b1"
                 elif net in gnd:
-                    net = "1b'0"
+                    net = "1'b0"
                 else:
                     net = mangle(net)
                 print(f'  ._{(pin)}({net})')


### PR DESCRIPTION
I believe that the right syntax is 1'b0 and 1'b1 for VCC and GND.